### PR TITLE
Added helper method to generate webtask urls and provide Promise for calling them

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,29 @@ with the 3-argument webtask signature:
 ```javascript
 function (context, req, res) {}
 ```
+
+## Runner.getTask(name, container, [base_url])
+
+Returns an object containing a url and a function to run the webtask:
+
+```javascript
+{
+    url: ...,
+    run: function (ctx, [opts]) {}
+}
+```
+
+Example:
+
+```javascript
+var myTask = getTask('my-task', 'sandbox-1');
+
+var args = {
+  foo: 'bar'
+}
+
+myTask
+    .run(ctx, args)
+    .then(function (res, body) {  })
+    .catch(function (err) {})
+```

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function getTask (name, container, base_url) {
 
     return {
         url: url,
-        run: function(ctx, opts) {
+        run: function(ctx, args, opts) {
             if(!opts) opts = {};
 
             return new Promise(function (resolve, reject) {
@@ -40,7 +40,7 @@ function getTask (name, container, base_url) {
                     method: opts.method || 'POST',
                     json:   opts.json   || true,
                     query:  opts.query,
-                    body:   opts.body
+                    body:   args
 
                 }, function (err, res, body) {
                     if(err) return reject(err);

--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
+var request = require('request');
+var path    = require('path');
+
 function fromConnect (connectFn) {
     return function (context, req, res) {
         req.url = req.url.replace('/api/run/', '/');
@@ -11,10 +14,44 @@ function fromServer (httpServer) {
     return function (context, req, res) {
         req.url = req.url.replace('/api/run/', '/');
         req.webtaskContext = context;
-        
+
         return httpServer.emit('request', req, res);
     };
 }
 
+function getTask (name, container, base_url) {
+
+    var url = base_url || 'https://webtask.it.auth0.com/' +
+        path.join(
+            'api',
+            'run',
+            encodeURIComponent(container),
+            encodeURIComponent(name) + '?webtask_no_cache=1'
+        );
+
+    return {
+        url: url,
+        run: function(ctx, opts) {
+            if(!opts) opts = {};
+
+            return new Promise(function (resolve, reject) {
+                request({
+                    url:    url,
+                    method: opts.method || 'POST',
+                    json:   opts.json   || true,
+                    query:  opts.query,
+                    body:   opts.body
+
+                }, function (err, res, body) {
+                    if(err) return reject(err);
+
+                    resolve(res, body);
+                });
+            });
+        }
+    };
+}
+
 exports.fromConnect = exports.fromExpress = fromConnect;
-exports.fromServer = exports.fromRestify = fromServer;
+exports.fromServer  = exports.fromRestify = fromServer;
+exports.getTask     = getTask;


### PR DESCRIPTION
Not sure about the API, currently also only supports named tokens, but I can't see why you would want to use a token unless generating a task on the fly, in which case you're better off on your own anyway.