### PR TITLE
Refactoring with Jared's feedback

### DIFF
--- a/lib/auth0/appEndpointHandler.js
+++ b/lib/auth0/appEndpointHandler.js
@@ -1,46 +1,34 @@
-var error = require('./error');
-
 module.exports = function (webtask, options, ctx, req, res, routingInfo) {
     return options.exclude && options.exclude(ctx, req, routingInfo.appPath)
         ? run()
         : authenticate();
 
     function authenticate() {
-        var apiKey = options.getApiKey(ctx, req);
-        if (!apiKey) {
+        var token = options.getAccessToken(ctx, req);
+        if (!token) {
             return options.loginError({
                 code: 401,
                 message: 'Unauthorized.',
-                error: 'Missing apiKey.',
+                error: 'Missing access token.',
                 redirect: routingInfo.baseUrl + '/login'
             }, ctx, req, res, routingInfo.baseUrl);
         }
+        options.validateToken(ctx, req, token, function (error, user) {
+            if (error) {
+                return options.loginError({
+                    code: error.code || 401,
+                    message: error.message || 'Unauthorized.'
+                }, ctx, req, res, routingInfo.baseUrl);
+            }
+            else {
+                ctx.accessToken = token;
+                ctx.user = req.user = user;
+                authorize();
+            }
+        });
+    }
 
-        // Authenticate
-
-        var secret = options.webtaskSecret(ctx, req);
-        if (!secret) {
-            return error({
-                code: 400,
-                message: 'The webtask secret must be provided to allow for validating apiKeys.'
-            }, res);
-        }
-
-        try {
-            ctx.user = req.user = require('jsonwebtoken').verify(apiKey, secret);
-        }
-        catch (e) {
-            return options.loginError({
-                code: 401,
-                message: 'Unauthorized.',
-                error: e.message
-            }, ctx, req, res, routingInfo.baseUrl);       
-        }
-
-        ctx.apiKey = apiKey;
-
-        // Authorize
-
+    function authorize() {
         if  (options.authorized && !options.authorized(ctx, req)) {
             return options.loginError({
                 code: 403,

--- a/lib/auth0/auth0.js
+++ b/lib/auth0/auth0.js
@@ -1,8 +1,8 @@
 var url = require('url');
-var error = require('./error');
 var handleAppEndpoint = require('./appEndpointHandler');
 var handleLogin = require('./loginHandler');
 var handleCallback = require('./callbackHandler');
+var getAuthParams = require('./authParams');
 
 module.exports = function (webtask, options) {
     if (typeof webtask !== 'function' || webtask.length !== 3) {
@@ -32,11 +32,14 @@ module.exports = function (webtask, options) {
     if (options.domain && typeof options.domain !== 'function') {
         throw new Error('The domain option, if specified, must be a function that accepts (ctx, req) and returns an Auth0 Domain.');
     }
-    if (options.webtaskSecret && typeof options.webtaskSecret !== 'function') {
-        throw new Error('The webtaskSecret option, if specified, must be a function that accepts (ctx, req) and returns a key to be used to sign issued JWT tokens.');
+    if (options.createToken && typeof options.createToken !== 'function') {
+        throw new Error('The createToken option, if specified, must be a function that accepts (ctx, res, idToken, accessToken) and returns an access token that can be used to authenticate future calls to webtask APIs.');
     }
-    if (options.getApiKey && typeof options.getApiKey !== 'function') {
-        throw new Error('The getApiKey option, if specified, must be a function that accepts (ctx, req) and returns an apiKey associated with the request.');
+    if (options.getAccessToken && typeof options.getAccessToken !== 'function') {
+        throw new Error('The getAccessToken option, if specified, must be a function that accepts (ctx, req) and returns the access token associated with the request, or null.');
+    }
+    if (options.validateToken && typeof options.validateToken !== 'function') {
+        throw new Error('The validateToken option, if specified, must be a function that accepts (ctx, req, token, cb) and calls the callback with (error, userProfile).');
     }
     if (options.loginSuccess && typeof options.loginSuccess !== 'function') {
         throw new Error('The loginSuccess option, if specified, must be a function that accepts (ctx, req, res, baseUrl) and generates a response.');
@@ -54,43 +57,64 @@ module.exports = function (webtask, options) {
     options.domain = options.domain || function (ctx, req) {
         return ctx.secrets.AUTH0_DOMAIN;
     };
-    options.webtaskSecret = options.webtaskSecret || function (ctx, req) {
-        // By default we don't expect developers to specify WEBTASK_SECRET when
-        // creating authenticated webtasks. In this case we will use webtask token
-        // itself as a JWT signing key. The webtask token of a named webtask is secret
-        // and it contains enough entropy (jti, iat, ca) to pass
-        // for a symmetric key. Using webtask token ensures that the JWT signing secret 
-        // remains constant for the lifetime of the webtask; however regenerating 
-        // the webtask will invalidate previously issued JWTs. 
-        return ctx.secrets.WEBTASK_SECRET || req.x_wt.token;
+    options.createToken = options.createToken || function (ctx, req, idToken, accessToken) {
+        return idToken;
     };
-    options.getApiKey = options.getApiKey || function (ctx, req) {
+    options.getAccessToken = options.getAccessToken || function (ctx, req) {
         if (req.headers.authorization && req.headers.authorization.split(' ')[0] === 'Bearer') {
             return req.headers.authorization.split(' ')[1];
-        } else if (req.query && req.query.apiKey) {
-            return req.query.apiKey;
+        } else {
+            return req.query && req.query.access_token;
         }
-        return null;
+    };
+    options.validateToken = options.validateToken || function (ctx, req, token, cb) {
+        var authParams = getAuthParams(options, ctx, req);
+        if (!authParams) {
+            return cb({
+                code: 400,
+                message: 'Auth0 Client ID, Client Secret, and Auth0 Domain must be specified.'
+            });
+        }
+
+        // Validate Auth0 issued id_token
+        var user;
+        try {
+            user = require('jsonwebtoken').verify(token, new Buffer(authParams.clientSecret, 'base64'), {
+                audience: authParams.clientId,
+                issuer: 'https://' + authParams.domain + '/'
+            });
+        }
+        catch (e) {
+            return cb({
+                code: 401,
+                message: 'Unauthorized: ' + e.message
+            });
+        }
+        return cb(null, user);
     };
     options.loginSuccess = options.loginSuccess || function (ctx, req, res, baseUrl) {
-        res.writeHead(302, { Location: baseUrl + '?apiKey=' + ctx.apiKey });
+        res.writeHead(302, { Location: baseUrl + '?access_token=' + ctx.accessToken });
         return res.end();
     };
-    options.loginError = options.loginError || function (error, ctx, req, res, baseUrl) {
+    options.loginError = options.loginError || function (err, ctx, req, res, baseUrl) {
         if (req.method === 'GET') {
-            if (error.redirect) {
-                res.writeHead(302, { Location: error.redirect });
-                return res.end(JSON.stringify(error));
+            if (err.redirect) {
+                res.writeHead(302, { Location: err.redirect, 'x-wt-error': err.message });
+                return res.end(JSON.stringify(err));
             }
-            res.writeHead(error.code || 401, { 
+            else if (err.code === 400) {
+                return error(err, res);
+            }
+            res.writeHead(err.code || 401, { 
                 'Content-Type': 'text/html', 
-                'Cache-Control': 'no-cache' 
+                'Cache-Control': 'no-cache',
+                'x-wt-error': err.message
             });
             return res.end(getNotAuthorizedHtml(baseUrl + '/login'));
         }
         else {
             // Reject all other requests
-            return error(error, res);
+            return error(err, res);
         }            
     };
     if (typeof options.authorized === 'string') {
@@ -204,4 +228,12 @@ var notAuthorizedTemplate = function () {/*
 
 function getNotAuthorizedHtml(loginUrl) {
     return notAuthorizedTemplate.replace('##', loginUrl);
+}
+
+function error(err, res) {
+    res.writeHead(err.code || 500, { 
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-cache'
+    });
+    res.end(JSON.stringify(err));
 }

--- a/lib/auth0/authParams.js
+++ b/lib/auth0/authParams.js
@@ -1,0 +1,9 @@
+module.exports = function (options, ctx, req) {
+    var authParams = {
+        clientId: options.clientId(ctx, req),
+        domain: options.domain(ctx, req),
+        clientSecret: options.clientSecret(ctx, req)
+    };
+    var count = !!authParams.clientId + !!authParams.domain + !!authParams.clientSecret;
+    return count === 3 ? authParams : null;
+};

--- a/lib/auth0/callbackHandler.js
+++ b/lib/auth0/callbackHandler.js
@@ -1,4 +1,4 @@
-var error = require('./error');
+var getAuthParams = require('./authParams')
 
 module.exports = function (options, ctx, req, res, routingInfo) {
     if (!ctx.query.code) {
@@ -9,17 +9,12 @@ module.exports = function (options, ctx, req, res, routingInfo) {
         }, ctx, req, res, routingInfo.baseUrl);
     }
 
-    var authParams = {
-        clientId: options.clientId(ctx, req),
-        domain: options.domain(ctx, req),
-        clientSecret: options.clientSecret(ctx, req)
-    };
-    var count = !!authParams.clientId + !!authParams.domain + !!authParams.clientSecret;
-    if (count !== 3) {
-        return error({
+    var authParams = getAuthParams(options, ctx, req);
+    if (!authParams) {
+        return options.loginError({
             code: 400,
             message: 'Auth0 Client ID, Client Secret, and Auth0 Domain must be specified.'
-        }, res);
+        }, ctx, res, res, routingInfo.baseUrl);
     }
 
     return require('superagent')
@@ -44,14 +39,13 @@ module.exports = function (options, ctx, req, res, routingInfo) {
                 }, ctx, req, res, routingInfo.baseUrl);
             }
 
-            return issueApiKey(ares.body.id_token);
+            return issueAccessToken(ares.body.id_token, ares.body.access_token);
         });
 
-    function issueApiKey(id_token) {
+    function issueAccessToken(id_token, access_token) {
         var jwt = require('jsonwebtoken');
-        var claims;
         try {
-            claims = jwt.decode(id_token);
+            req.user = ctx.user = jwt.decode(id_token);
         }
         catch (e) {
             return options.loginError({
@@ -62,22 +56,15 @@ module.exports = function (options, ctx, req, res, routingInfo) {
             }, ctx, req, res, routingInfo.baseUrl);
         }
 
-        // Issue apiKey by re-signing the id_token claims 
-        // with configured secret (webtask token by default).
-
-        var secret = options.webtaskSecret(ctx, req);
-        if (!secret) {
-            return error({
+        ctx.accessToken = options.createToken(ctx, req, id_token, access_token);
+        if (typeof ctx.accessToken !== 'string') {
+            return options.loginError({
                 code: 400,
-                message: 'The webtask secret must be be provided to allow for issuing apiKeys.'
-            }, res);
+                message: 'The createToken function did not return a string access token.'
+            }, ctx, req, res, routingInfo.baseUrl);
         }
 
-        claims.iss = routingInfo.baseUrl;
-        req.user = ctx.user = claims;
-        ctx.apiKey = jwt.sign(claims, secret);
-
-        // Perform post-login action (redirect to /?apiKey=... by default)
+        // Perform post-login action (redirect to /?access_token=... by default)
         return options.loginSuccess(ctx, req, res, routingInfo.baseUrl);
     }
 };

--- a/lib/auth0/error.js
+++ b/lib/auth0/error.js
@@ -1,7 +1,0 @@
-module.exports = function (err, res) {
-    res.writeHead(err.code || 500, { 
-        'Content-Type': 'application/json',
-        'Cache-Control': 'no-cache'
-    });
-    res.end(JSON.stringify(err));
-};

--- a/lib/auth0/loginHandler.js
+++ b/lib/auth0/loginHandler.js
@@ -1,18 +1,14 @@
-var error = require('./error');
+var getAuthParams = require('./authParams');
 
 module.exports = function(options, ctx, req, res, routingInfo) {
-    var authParams = {
-        clientId: options.clientId(ctx, req),
-        domain: options.domain(ctx, req)
-    };
-    var count = !!authParams.clientId + !!authParams.domain;
+    var authParams = getAuthParams(options, ctx, req);
     var scope = 'openid name email email_verified ' + (options.scope || '');
-    if (count ===  0) {
+    if (!authParams) {
         // TODO, tjanczuk, support the shared Auth0 application case
-        return error({
-            code: 501,
-            message: 'Not implemented.'
-        }, res);
+        return options.loginError({
+            code: 400,
+            message: 'You must specify Auth0 client ID, client secret, and domain when creating the webtask. See https://webtask.io/docs/auth for details.'
+        }, ctx, req, res, routingInfo.baseUrl);
         // Neither client id or domain are specified; use shared Auth0 settings
         // var authUrl = 'https://auth0.auth0.com/i/oauth2/authorize'
         //     + '?response_type=code'
@@ -23,7 +19,7 @@ module.exports = function(options, ctx, req, res, routingInfo) {
         // res.writeHead(302, { Location: authUrl });
         // return res.end();
     }
-    else if (count === 2) {
+    else {
         // Use custom Auth0 account
         var authUrl = 'https://' + authParams.domain + '/authorize' 
             + '?response_type=code'
@@ -32,11 +28,5 @@ module.exports = function(options, ctx, req, res, routingInfo) {
             + '&redirect_uri=' + encodeURIComponent(routingInfo.baseUrl + '/callback');
         res.writeHead(302, { Location: authUrl });
         return res.end();
-    }
-    else {
-        return error({
-            code: 400,
-            message: 'Both or neither Auth0 Client ID and Auth0 domain must be specified.'
-        }, res);
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webtask-tools",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Tools to facilitate working in a webtask context",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
1. options.webtaskSecret is gone  
2. options.createToken(ctx, req, idToken, accessToken) => newAccessToken introduced. By default returns idToken. 
3. options.validateToken(ctx, req, token, cb) added. This is to validate the token and return a "user" object to put in req.user. Async to allow for future RSA signatures. By default validates the token is signed with Auth0 client secret and for the proper aud and iss.  
4. options.getApiKey renamed to options.getAccessToken  
5. ctx.apiKey renamed to ctx.accessToken  
6. ?apiKey query param renamed to ?access_token  
