### PR TITLE
Handle newer client secrets stored without base64 encoding, along with subdomain URLs.

### DIFF
--- a/lib/auth0/auth0.js
+++ b/lib/auth0/auth0.js
@@ -1,4 +1,5 @@
 var url = require('url');
+var Buffer = require('safe-buffer').Buffer
 var handleAppEndpoint = require('./appEndpointHandler');
 var handleLogin = require('./loginHandler');
 var handleCallback = require('./callbackHandler');
@@ -29,6 +30,9 @@ module.exports = function (webtask, options) {
     if (options.clientSecret && typeof options.clientSecret !== 'function') {
         throw new Error('The clientSecret option, if specified, must be a function that accepts (ctx, req) and returns an Auth0 Client Secret.');
     }
+    if (options.secretEncoding && typeof options.secretEncoding !== 'function') {
+        throw new Error('The secretEncoding option, if specified, must be a function that accepts (ctx, req) and returns a character encoding name for use with the "Buffer" class.');
+    }
     if (options.domain && typeof options.domain !== 'function') {
         throw new Error('The domain option, if specified, must be a function that accepts (ctx, req) and returns an Auth0 Domain.');
     }
@@ -53,6 +57,9 @@ module.exports = function (webtask, options) {
     };
     options.clientSecret = options.clientSecret || function (ctx, req) {
         return ctx.secrets.AUTH0_CLIENT_SECRET;
+    };
+    options.secretEncoding = options.secretEncoding || function (ctx, req) {
+        return (ctx.secrets.AUTH0_SECRET_ENCODING === undefined) ? 'base64' : ctx.secrets.AUTH0_SECRET_ENCODING;
     };
     options.domain = options.domain || function (ctx, req) {
         return ctx.secrets.AUTH0_DOMAIN;
@@ -79,7 +86,7 @@ module.exports = function (webtask, options) {
         // Validate Auth0 issued id_token
         var user;
         try {
-            user = require('jsonwebtoken').verify(token, new Buffer(authParams.clientSecret, 'base64'), {
+            user = require('jsonwebtoken').verify(token, new Buffer(authParams.clientSecret, authParams.secretEncoding), {
                 audience: authParams.clientId,
                 issuer: 'https://' + authParams.domain + '/'
             });

--- a/lib/auth0/authParams.js
+++ b/lib/auth0/authParams.js
@@ -2,8 +2,9 @@ module.exports = function (options, ctx, req) {
     var authParams = {
         clientId: options.clientId(ctx, req),
         domain: options.domain(ctx, req),
-        clientSecret: options.clientSecret(ctx, req)
+        clientSecret: options.clientSecret(ctx, req),
+        secretEncoding: options.secretEncoding(ctx, req)
     };
-    var count = !!authParams.clientId + !!authParams.domain + !!authParams.clientSecret;
-    return count === 3 ? authParams : null;
+    var count = !!authParams.clientId + !!authParams.domain + !!authParams.clientSecret + !!authParams.secretEncoding;
+    return count === 4 ? authParams : null;
 };


### PR DESCRIPTION
The change made on 12/6/2016 to the way client secrets are stored (without base64 encoding) created an issue when using the **webtask-tools** package to authenticate a webtask against Auth0 clients created after that date.

This PR proposes that webtasks using clients created after 12/06/2016 define an additional secret of AUTH0_SECRET_ENCODING={encoding} when they are created, in addition to the usual AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET, and AUTH0_DOMAIN secrets. This new parameter informs the **webtask-tools** package which character encoding to use for the secret when validating a request token.

If the AUTH0_SECRET_ENCODING secret is not provided, the {encoding} defaults to 'base64' to retain backwards compatibility with existing webtasks and clients created prior to 12/06/2016. Webtasks using clients created after 12/06/2016 can use an {encoding} of 'utf8'.

This change also supports subdomain URLs of the form **https://{container}.us.webtask.io/{jtn}**, as produced by the `wt create` command and described in the forum thread _"[Problem authenticating a webtask with Auth0](https://auth0.com/forum/t/problem-authenticating-a-webtask-with-auth0/4596)"_.