### PR TITLE
Pass extra path info and query parameters as 'state' across login

### DIFF
--- a/lib/auth0/appEndpointHandler.js
+++ b/lib/auth0/appEndpointHandler.js
@@ -6,11 +6,15 @@ module.exports = function (webtask, options, ctx, req, res, routingInfo) {
     function authenticate() {
         var token = options.getAccessToken(ctx, req);
         if (!token) {
+            var stateInfo = {
+                appPath: routingInfo.appPath,
+                query: routingInfo.query
+            };
             return options.loginError({
                 code: 401,
                 message: 'Unauthorized.',
                 error: 'Missing access token.',
-                redirect: routingInfo.baseUrl + '/login'
+                redirect: routingInfo.baseUrl + '/login?state=' + encodeURIComponent(JSON.stringify(stateInfo))
             }, ctx, req, res, routingInfo.baseUrl);
         }
         options.validateToken(ctx, req, token, function (error, user) {

--- a/lib/auth0/auth0.js
+++ b/lib/auth0/auth0.js
@@ -93,7 +93,12 @@ module.exports = function (webtask, options) {
         return cb(null, user);
     };
     options.loginSuccess = options.loginSuccess || function (ctx, req, res, baseUrl) {
-        res.writeHead(302, { Location: baseUrl + '?access_token=' + ctx.accessToken });
+        var stateInfo = { appPath: '/', query: {} };
+        if (ctx.query && ctx.query.state) {
+            stateInfo = JSON.parse(decodeURIComponent(ctx.query.state));
+        };
+        var query = Object.assign({}, stateInfo.query, {access_token: ctx.accessToken});
+        res.writeHead(302, { Location: baseUrl + stateInfo.appPath + '?' + require('querystring').stringify(query) });
         return res.end();
     };
     options.loginError = options.loginError || function (err, ctx, req, res, baseUrl) {

--- a/lib/auth0/loginHandler.js
+++ b/lib/auth0/loginHandler.js
@@ -3,6 +3,10 @@ var getAuthParams = require('./authParams');
 module.exports = function(options, ctx, req, res, routingInfo) {
     var authParams = getAuthParams(options, ctx, req);
     var scope = 'openid name email email_verified ' + (options.scope || '');
+    var stateInfo = { appPath: '/', query: {} };
+    if (ctx.query && ctx.query.state) {
+        stateInfo = JSON.parse(decodeURIComponent(ctx.query.state));
+    };
     if (!authParams) {
         // TODO, tjanczuk, support the shared Auth0 application case
         return options.loginError({
@@ -15,6 +19,7 @@ module.exports = function(options, ctx, req, res, routingInfo) {
         //     + '&audience=https://auth0.auth0.com/userinfo'
         //     + '&scope=' + encodeURIComponent(scope)
         //     + '&client_id=' + encodeURIComponent(routingInfo.baseUrl)
+        //     + '&state=' + encodeURIComponent(JSON.stringify(stateInfo))
         //     + '&redirect_uri=' + encodeURIComponent(routingInfo.baseUrl + '/callback');
         // res.writeHead(302, { Location: authUrl });
         // return res.end();
@@ -25,6 +30,7 @@ module.exports = function(options, ctx, req, res, routingInfo) {
             + '?response_type=code'
             + '&scope=' + encodeURIComponent(scope)
             + '&client_id=' + encodeURIComponent(authParams.clientId)
+            + '&state=' + encodeURIComponent(JSON.stringify(stateInfo))
             + '&redirect_uri=' + encodeURIComponent(routingInfo.baseUrl + '/callback');
         res.writeHead(302, { Location: authUrl });
         return res.end();


### PR DESCRIPTION
On the next revision, can we have webtask-tools remember the original URL request and pass it as state information?

Our use-case is to let a user/app start at a “deep link” like:

`https://{container}.us.webtask.io/{jtn}/extra/path/info?param=value`

then go through the authentication process, and end up back at that same link with the same query parameters after a successful login (and the addition of an access token to the request).

