### PR TITLE
Adding 'edge' dependency used in index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webtask-tools",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Tools to facilitate working in a webtask context",
   "main": "./lib/index.js",
   "scripts": {
@@ -25,6 +25,7 @@
   "devDependencies": {},
   "dependencies": {
     "boom": "^2.7.2",
+    "edge": "^7.10.1",
     "jsonwebtoken": "^5.7.0",
     "pug": "^0.1.0",
     "safe-buffer": "^5.0.1",


### PR DESCRIPTION
This was breaking when building webtasks unless the developer had
already included `edge` in their package's dependencies. I'm unsure if
this is intentional or accidental so I am submitting this patch to
include it.

Error when building an extension via CLI `a0-ext`

```
ERROR in ./~/webtask-tools/lib/index.js
Module not found: Error: Can't resolve 'edge' in '/......./extension-package/node_modules/webtask-tools/lib'
 @ ./~/webtask-tools/lib/index.js 54:13-28
 @ ./webtask.js
```

This issue was previously raised at: #18 and is a fix.

@ggoodman could you provide some feedback on if this was intentional and if this fix will suffice?