### PR TITLE
Add support for tokens signed with RS256

### DIFF
--- a/lib/auth0/auth0.js
+++ b/lib/auth0/auth0.js
@@ -86,20 +86,29 @@ module.exports = function (webtask, options) {
         }
 
         // Validate Auth0 issued id_token
-        let user;
-        try {
-            user = require('jsonwebtoken').verify(token, Buffer.from(authParams.clientSecret, authParams.secretEncoding), {
-                audience: authParams.clientId,
-                issuer: 'https://' + authParams.domain + '/'
-            });
-        }
-        catch (e) {
-            return cb({
-                code: 401,
-                message: 'Unauthorized: ' + e.message
-            });
-        }
-        return cb(null, user);
+        getSecretOrPublicKey(authParams, token, function (err, secretOrPublicKey) {
+            if (err) {
+                return cb({
+                    code: 400,
+                    message: err.message
+                });
+            }
+        
+            let user;
+            try {
+                user = require('jsonwebtoken').verify(token, secretOrPublicKey, {
+                    audience: authParams.clientId,
+                    issuer: 'https://' + authParams.domain + '/'
+                });
+            }
+            catch (e) {
+                return cb({
+                    code: 401,
+                    message: 'Unauthorized: ' + e.message
+                });
+            }
+            return cb(null, user);
+        });
     };
     options.loginSuccess = options.loginSuccess || function (ctx, req, res, baseUrl) {
         res.writeHead(302, { Location: `${ baseUrl }?access_token=${ ctx.accessToken }` });
@@ -240,6 +249,37 @@ function getNotAuthorizedHtml(loginUrl) {
     </html>`;
 
     return notAuthorizedTemplate;
+}
+
+function getSecretOrPublicKey(authParams, token, callback) {
+    const decoded = require('jsonwebtoken').decode(token, { complete: true });
+
+    if (decoded.header.alg !== 'RS256') {
+        return callback(null, Buffer.from(authParams.clientSecret, authParams.secretEncoding));
+    }
+
+    require('superagent')
+        .get('https://' + authParams.domain + '/.well-known/jwks.json')
+        .set('Accept', 'application/json')
+        .timeout(15000)
+        .end(function (err, res) {
+            if (err || !res.ok || !res.body || !res.body.keys || !Array.isArray(res.body.keys)) {
+                return callback({
+                    code: 400,
+                    message: 'Unable to retrieve JWKS.'
+                });
+            }
+
+            const publicKey = res.body.keys.reduce(function (prev, key) {
+                if (key.use === 'sig' && key.kty === 'RSA' && key.kid === decoded.header.kid && key.x5c && key.x5c.length) {
+                    return `-----BEGIN CERTIFICATE-----\n${ key.x5c[0].match(/.{1,64}/g).join('\n') }\n-----END CERTIFICATE-----\n`;
+                } else {
+                    return prev;
+                }
+            }, '');
+
+            callback(null, publicKey);
+        });
 }
 
 function error(err, res) {


### PR DESCRIPTION
**Bug report:** https://github.com/auth0/webtask-tools/issues/20

**Overview:** The current implementation does not support access tokens signed with RS256. This pull request adds backwards-compatible support.

**Implementation:** The validation process was failing due to the fact that `jsonwebtoken` decodes the token and applies the algorithm included in the header. Currently, Auth0 access tokens have `alg` set to `RS256` but a client secret is being provided instead of a public key.

To solve for this, it was necessary to preemptively check `alg` and pivot accordingly. If the algorithm is anything other than `RS256`, it returns the client secret as a buffer (taking into account the secret's encoding). This is consistent with the current implementation. If the algorithm is `RS256` then a request is made at the tenant's JWKS endpoint [as outlined here](https://auth0.com/blog/navigating-rs256-and-jwks/). A public key is then generated and returned.

**Considerations:**
- A synchronous implementation would have been preferable perhaps but given the fact that an http request was necessary and async await is not used in the project, CPS (callback) was used.
- `superagent` and `jsonwebtoken` were the only required dependencies and both were already part of the project so no new deps were added.
- No _new_ ESLint errors were produced as a result of this pull request and great care was taken to match the current coding style as much as possible.
- There is no test suite for this project. Consequently, the implementation was stubbed and tested locally but more formal testing may be required before the pull request is ready to be accepted. I am happy to help in any way that I can.