### PR TITLE
Update Webtask-tools npm dependency versions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ exports.fromServer = exports.fromRestify = fromServer;
 var app = new (require('express'))();
 
 app.get('/', function (req, res) {
-   res.send('Hello, world'); 
+   res.send('Hello, world');
 });
 
 module.exports = app;
@@ -41,13 +41,13 @@ function render(options, cb, render) {
     cb(null, (ctx, req, res) => {
         res.writeHead(200, { 'Content-Type': 'text/html' });
         var html = render(options.script);
-        res.end(html);    
-    });   
-} 
+        res.end(html);
+    });
+}
 
 /*
 async (dynamic context) => {
-    return "Hello, world!";  
+    return "Hello, world!";
 }
 */
 exports.cs = function (options, cb) {
@@ -121,7 +121,7 @@ function createRouteNormalizationRx(claims) {
     var name = claims.jtn
         ? claims.jtn.replace(SANITIZE_RX, '\\$&')
         : '';
-    
+
     if (claims.url_format === USE_SHARED_DOMAIN) {
         return new RegExp(`^\/api/run/${container}/(?:${name}\/?)?`);
     }
@@ -174,9 +174,9 @@ function attachStorageHelpers(context) {
             qs: { path: path },
             json: true,
         }, function (err, res, body) {
-            if (err) return cb(Boom.wrap(err, 502));
+            if (err) return cb(Boom.boomify(err, { statusCode: 502 }));
             if (res.statusCode === 404 && Object.hasOwnProperty.call(options, 'defaultValue')) return cb(null, options.defaultValue);
-            if (res.statusCode >= 400) return cb(Boom.create(res.statusCode, body && body.message));
+            if (res.statusCode >= 400) return cb(new Boom(body && body.message, { statusCode: res.statusCode }));
 
             cb(null, body);
         });
@@ -209,8 +209,8 @@ function attachStorageHelpers(context) {
             qs: { path: path },
             body: data,
         }, function (err, res, body) {
-            if (err) return cb(Boom.wrap(err, 502));
-            if (res.statusCode >= 400) return cb(Boom.create(res.statusCode, body && body.message));
+            if (err) return cb(Boom.boomify(err, { statusCode: 502 }));
+            if (res.statusCode >= 400) return cb(new Boom(body && body.message, { statusCode: res.statusCode }));
 
             cb(null);
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webtask-tools",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Tools to facilitate working in a webtask context",
   "main": "./lib/index.js",
   "scripts": {
@@ -24,10 +24,10 @@
   "homepage": "https://github.com/auth0/webtask-tools#readme",
   "devDependencies": {},
   "dependencies": {
-    "boom": "^2.7.2",
+    "boom": "^7.2.0",
     "jsonwebtoken": "^5.7.0",
     "pug": "^0.1.0",
     "safe-buffer": "^5.0.1",
-    "superagent": "^1.8.3"
+    "superagent": "^3.8.3"
   }
 }


### PR DESCRIPTION
New `webtask-tools` version: 3.4.0
Current `webtask-tools` version: 3.3.0

**This change should not introduce any breaking changes**

Work Items:
- Move the latest version of `superagent` (https://auth0team.atlassian.net/browse/EX-1132)
  - Current version is `1.8.3`
  - New version is now `3.8.3`
  - I have looked at the two places in the code where we use superagent and made sure the newest version does not have any breaking changes as we use the module today.

- Move to the lastes version of `boom` (https://auth0team.atlassian.net/browse/EX-1135)
  - Current version is `2.7.2`
  - New version is now `7.2.0`
  - I have looked at the 3 different ways we use the boom module, and either updated the usage to get the same behavior as before or verified that the behavior has not changed. 



